### PR TITLE
Radiolib sync upstream

### DIFF
--- a/src/mesh/RadioLibRF95.cpp
+++ b/src/mesh/RadioLibRF95.cpp
@@ -10,7 +10,7 @@
 
 RadioLibRF95::RadioLibRF95(Module *mod) : SX1278(mod) {}
 
-int16_t RadioLibRF95::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, int8_t power, uint8_t currentLimit,
+int16_t RadioLibRF95::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, int8_t power,
                             uint16_t preambleLength, uint8_t gain)
 {
     // execute common part

--- a/src/mesh/RadioLibRF95.cpp
+++ b/src/mesh/RadioLibRF95.cpp
@@ -14,9 +14,9 @@ int16_t RadioLibRF95::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_
                             uint16_t preambleLength, uint8_t gain)
 {
     // execute common part
-    int16_t state = SX127x::begin(RF95_CHIP_VERSION, syncWord, currentLimit, preambleLength);
+    int16_t state = SX127x::begin(RF95_CHIP_VERSION, syncWord, preambleLength);
     if (state != ERR_NONE)
-        state = SX127x::begin(RF95_ALT_VERSION, syncWord, currentLimit, preambleLength);
+        state = SX127x::begin(RF95_ALT_VERSION, syncWord, preambleLength);
     RADIOLIB_ASSERT(state);
 
     // configure settings not accessible by API

--- a/src/mesh/RadioLibRF95.h
+++ b/src/mesh/RadioLibRF95.h
@@ -35,9 +35,6 @@ class RadioLibRF95: public SX1278 {
 
       \param power Transmission output power in dBm. Allowed values range from 2 to 17 dBm.
 
-      \param currentLimit Trim value for OCP (over current protection) in mA. Can be set to multiplies of 5 in range 45 to 120 mA and to multiples of 10 in range 120 to 240 mA.
-      Set to 0 to disable OCP (not recommended).
-
       \param preambleLength Length of %LoRa transmission preamble in symbols. The actual preamble length is 4.25 symbols longer than the set number.
       Allowed values range from 6 to 65535.
 
@@ -46,7 +43,7 @@ class RadioLibRF95: public SX1278 {
 
       \returns \ref status_codes
     */
-    int16_t begin(float freq = 915.0, float bw = 125.0, uint8_t sf = 9, uint8_t cr = 7, uint8_t syncWord = SX127X_SYNC_WORD, int8_t power = 17, uint8_t currentLimit = 100, uint16_t preambleLength = 8, uint8_t gain = 0);
+    int16_t begin(float freq = 915.0, float bw = 125.0, uint8_t sf = 9, uint8_t cr = 7, uint8_t syncWord = SX127X_SYNC_WORD, int8_t power = 17, uint16_t preambleLength = 8, uint8_t gain = 0);
 
     // configuration methods
 

--- a/src/mesh/SX1262Interface.cpp
+++ b/src/mesh/SX1262Interface.cpp
@@ -50,7 +50,7 @@ bool SX1262Interface::init()
 
     limitPower();
 
-    int res = lora.begin(freq, bw, sf, cr, syncWord, power, currentLimit, preambleLength, tcxoVoltage, useRegulatorLDO);
+    int res = lora.begin(freq, bw, sf, cr, syncWord, power, preambleLength, tcxoVoltage, useRegulatorLDO);
     DEBUG_MSG("SX1262 init result %d\n", res);
 
 #ifdef SX1262_TXEN


### PR DESCRIPTION
To reflect changes in the updated RadioLib (#849) we need slightly modify these two adapters:

- RadioLibRF95
- SX1262Interface

as the argument `currentLimit` was removed from the `begin` method:
jgromes/RadioLib@e1141ca#diff-507c32190e4a29ffe411c8eab06c75b594c5d2a5fd92e5cb703b787e5f019589L568